### PR TITLE
Disable autocomplete for the default template.

### DIFF
--- a/ldap_connection.go
+++ b/ldap_connection.go
@@ -55,7 +55,7 @@ func (l *LdapConnection) VerifyUserPass(username string, password string) bool {
 	// First bind with a read only user
 	err = ldap_con.Bind(l.BindDN, l.BindDNPassword)
 	if err != nil {
-		log.Printf("Error binding LDAP: ", err)
+		log.Printf("Error binding LDAP: %v", err)
 		return false
 	}
 

--- a/options.go
+++ b/options.go
@@ -149,7 +149,7 @@ func (o *Options) Validate() error {
 		_, cidr, err := net.ParseCIDR(u)
 		if err != nil {
 			msgs = append(msgs, fmt.Sprintf(
-				"error parsing cidr", u, err))
+				"error parsing cidr %q: %v", u, err))
 		}
 		o.skipIPs = append(o.skipIPs, cidr)
 	}

--- a/templates.go
+++ b/templates.go
@@ -127,7 +127,7 @@ func getTemplates() *template.Template {
 	<form method="POST" action="{{.ProxyPrefix}}/sign_in">
 		<input type="hidden" name="rd" value="{{.Redirect}}">
 		<label for="username">Username:</label><input type="text" name="username" id="username" size="10"><br/>
-		<label for="password">Password:</label><input type="password" name="password" id="password" size="10"><br/>
+		<label for="password">Password:</label><input type="password" name="password" id="password" size="10" autocomplete="off"><br/>
 		<button type="submit" class="btn">Sign In</button>
 	</form>
 	</div>

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.1.0"
+const VERSION = "0.1.1"


### PR DESCRIPTION
Follows best practice for forms with authentication / sensitive data.